### PR TITLE
Load the state from specified file

### DIFF
--- a/tftui/__main__.py
+++ b/tftui/__main__.py
@@ -49,6 +49,7 @@ class ApplicationGlobals:
     no_init = False
     darkmode = True
     var_file = None
+    state_file = None
 
 
 class AppHeader(Horizontal):
@@ -104,7 +105,9 @@ class StateTree(Tree):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.current_state = State(
-            executable=ApplicationGlobals.executable, no_init=ApplicationGlobals.no_init
+            executable=ApplicationGlobals.executable,
+            no_init=ApplicationGlobals.no_init,
+            state_file=ApplicationGlobals.state_file,
         )
         self.guide_depth = 3
         self.root.data = ""
@@ -723,6 +726,11 @@ def parse_command_line() -> None:
     parser.add_argument(
         "-v", "--version", help="show version information", action="store_true"
     )
+    parser.add_argument(
+        "-s",
+        "--state-file",
+        help="path to terraform show output file (if specified, use file content instead of running terraform show)",
+    )
     args = parser.parse_args()
 
     if args.offline or args.disable_usage_tracking:
@@ -738,8 +746,9 @@ def parse_command_line() -> None:
         ApplicationGlobals.executable = args.executable
     if args.var_file:
         ApplicationGlobals.var_file = args.var_file
+    if args.state_file:
+        ApplicationGlobals.state_file = args.state_file
     if args.generate_debug_log:
-        logger = setup_logging("debug")
         logger.debug("*" * 50)
         logger.debug(f"Debug log enabled (tftui v{OutboundAPIs.version})")
     ApplicationGlobals.darkmode = not args.light_mode

--- a/tftui/state.py
+++ b/tftui/state.py
@@ -8,7 +8,7 @@ from tftui.debug_log import setup_logging
 logger = setup_logging()
 
 
-async def execute_async(*command: str) -> tuple[str, str]:
+async def execute_async(*command: str) -> tuple[int, str]:
     command = [word for phrase in command for word in phrase.split()]
 
     proc = await asyncio.create_subprocess_exec(
@@ -23,7 +23,7 @@ async def execute_async(*command: str) -> tuple[str, str]:
         "Executed command: %s",
         json.dumps({"command": command, "return_code": proc.returncode}, indent=2),
     )
-    return (proc.returncode, response)
+    return (proc.returncode if proc.returncode is not None else 1, response)
 
 
 def extract_sensitive_values(stateTree: dict) -> dict[str, dict[str, str]]:
@@ -35,12 +35,10 @@ def extract_sensitive_values(stateTree: dict) -> dict[str, dict[str, str]]:
         ):
             sensitive_keys = stateTree.get("sensitive_values")
             if sensitive_keys:
-                secrets = {
-                    k: v
-                    for k, v in stateTree.get("values").items()
-                    if k in sensitive_keys
-                }
-                sensitive_values[stateTree.get("address")] = secrets
+                values = stateTree.get("values")
+                if values:
+                    secrets = {k: v for k, v in values.items() if k in sensitive_keys}
+                    sensitive_values[stateTree.get("address")] = secrets
         for value in stateTree.values():
             sensitive_values.update(extract_sensitive_values(value))
     elif isinstance(stateTree, list):
@@ -50,7 +48,6 @@ def extract_sensitive_values(stateTree: dict) -> dict[str, dict[str, str]]:
 
 
 def split_resource_name(fullname: str) -> list[str]:
-    # Thanks Chatgpt, couldn't do this without you; please don't become sentient and kill us all
     pattern = r"\.(?=(?:[^\[\]]*\[[^\[\]]*\])*[^\[\]]*$)"
     return re.split(pattern, fullname)
 
@@ -76,12 +73,15 @@ class State:
     state_tree = {}
     executable = ""
     no_init = False
+    state_file = None
 
-    def __init__(self, executable="terraform", no_init=False):
+    def __init__(self, executable="terraform", no_init=False, state_file=None):
         self.executable = executable
         self.no_init = no_init
+        self.state_file = state_file
 
-    def parse_block(line: str) -> tuple[str, str, str]:
+    @staticmethod
+    def parse_block(line: str) -> tuple[str, str, str, str, bool]:
         fullname = line[2 : line.rindex(":")]
         is_tainted = line.endswith("(tainted)")
         parts = split_resource_name(fullname)
@@ -97,9 +97,16 @@ class State:
         return (fullname, name, submodule, type, is_tainted)
 
     async def refresh_state(self) -> None:
-        returncode, stdout = await execute_async(self.executable, "show -no-color")
-        if returncode != 0:
-            raise Exception(stdout)
+        logger.critical(f"state loaded from file: {self.state_file}")
+        if self.state_file:
+            with open(self.state_file, "r", encoding="utf-8") as f:
+                stdout = f.read()
+            logger.debug(f"state loaded from file: {self.state_file}")
+            print("using cached state")
+        else:
+            returncode, stdout = await execute_async(self.executable, "show -no-color")
+            if returncode != 0:
+                raise Exception(stdout)
 
         self.state_tree = {}
         state_output = stdout.splitlines()
@@ -108,7 +115,7 @@ class State:
         contents = ""
         for line in state_output:
             if line.startswith("#"):
-                (fullname, name, submodule, type, is_tainted) = State.parse_block(line)
+                (fullname, name, submodule, type, is_tainted) = self.parse_block(line)
                 contents = ""
             elif line.startswith("}"):
                 contents += line.rstrip() + "\n"


### PR DESCRIPTION
The current implementation always runs `terraform show -no-color` internally to load the current state.
However, `terraform show` requires much time if the system is large, and we have to wait a long time in the situation.
For example, I have to wait 50 minutes to run the command on my system.

This PR changes the code to load a state from a file, which is the result of `terraform show -no-color`, and we avoid running the command when launching the tftui.

This is just a PoC implementation of the concept of loading a state from a file. The design is not good, we include irrelevant refactoring (by LLM), and we cannot refresh the state.

```
$ cd /path/to/terraform_dir/
$ terraform show -no-color > state.txt  
$ cd /path/to/tftui_dir/
$ poetry run python ./tftui/__main__.py -s /path/to/terraform_dir/state.txt --generate-debug-log 
```